### PR TITLE
add environment to filters

### DIFF
--- a/src/app/components/vulnerabilities/Vulnerabilities.tsx
+++ b/src/app/components/vulnerabilities/Vulnerabilities.tsx
@@ -11,11 +11,14 @@ const Vulnerabilities = () => {
     setTeamFilters,
     applicationFilters,
     setApplicationFilters,
+    environmentFilters,
+    setEnvironmentFilters,
     cveFilters,
     setCveFilters,
     packageNameFilters,
     setPackageNameFilters,
     allTeams,
+    availableEnvironments,
     availableApplications,
     availableCves,
     availablePackageNames,
@@ -45,6 +48,13 @@ const Vulnerabilities = () => {
             />
             <FilterActionMenu
               style={{ marginLeft: "1rem" }}
+              filterName="Environment"
+              filterOptions={availableEnvironments}
+              selectedFilters={environmentFilters}
+              setFilter={setEnvironmentFilters}
+            />
+            <FilterActionMenu
+              style={{ marginLeft: "1rem" }}
               filterName="Application"
               filterOptions={availableApplications}
               selectedFilters={applicationFilters}
@@ -69,6 +79,7 @@ const Vulnerabilities = () => {
             data={data}
             teamFilters={teamFilters}
             applicationFilters={applicationFilters}
+            environmentFilters={environmentFilters}
             cveFilters={cveFilters}
             packageNameFilters={packageNameFilters}
           />

--- a/src/app/components/vulnerabilities/table/VulnerabilitiesTable.tsx
+++ b/src/app/components/vulnerabilities/table/VulnerabilitiesTable.tsx
@@ -9,6 +9,7 @@ interface VulnerabilitiesTableProps {
   data?: VulnerabilitiesResponse;
   teamFilters: Record<string, boolean>;
   applicationFilters: Record<string, boolean>;
+  environmentFilters: Record<string, boolean>;
   cveFilters: Record<string, boolean>;
   packageNameFilters: Record<string, boolean>;
 }
@@ -20,6 +21,7 @@ const VulnerabilitiesTable = ({
   data,
   teamFilters,
   applicationFilters,
+  environmentFilters,
   cveFilters,
   packageNameFilters,
 }: VulnerabilitiesTableProps) => {
@@ -58,6 +60,7 @@ const VulnerabilitiesTable = ({
     const hasApplicationFilters = Object.values(applicationFilters).some(
       (v) => v
     );
+    const hasEnvironmentFilters = Object.values(environmentFilters).some((v) => v);
     const hasCveFilters = Object.values(cveFilters).some((v) => v);
     const hasPackageNameFilters = Object.values(packageNameFilters).some(
       (v) => v
@@ -69,8 +72,8 @@ const VulnerabilitiesTable = ({
         team.workloads.forEach((workload) => {
           // Show workload if no application filters OR workload is selected
           if (
-            !hasApplicationFilters ||
-            applicationFilters[workload.name]
+            (!hasApplicationFilters || applicationFilters[workload.name]) && 
+            (!hasEnvironmentFilters || environmentFilters[workload.environment])
           ) {
             workload.vulnerabilities.forEach((vulnerability) => {
               // Show CVE if no CVE filters OR CVE is selected
@@ -98,7 +101,7 @@ const VulnerabilitiesTable = ({
     });
 
     return rows;
-  }, [data, teamFilters, applicationFilters, cveFilters, packageNameFilters]);
+  }, [data, teamFilters, environmentFilters, applicationFilters, cveFilters, packageNameFilters]);
 
   const sortedRows = useMemo(() => {
     if (sort.direction === "none") return tableRows;

--- a/src/app/mocks/mockPayloads.ts
+++ b/src/app/mocks/mockPayloads.ts
@@ -51,6 +51,52 @@ export const mockVulnerabilitiesPayload = {
         },
         {
           id: "workload-002",
+          name: "TPT Frontend Application",
+          environment: "dev-gcp",
+          repository: "navikt/tpt-frontend",
+          ingressTypes: ["external"],
+          buildTime: "2025-11-27",
+          vulnerabilities: [
+            {
+              identifier: "CVE-2025-0001",
+              packageName: "express",
+              description:
+                "A buffer overflow vulnerability in the X.509 certificate parser could allow remote code execution",
+              vulnerabilityDetailsLink:
+                "https://nvd.nist.gov/vuln/detail/CVE-2025-0001",
+              riskScore: 200,
+              riskScoreMultipliers: {
+                base_high: 70,
+                exposure: 2,
+                kev: 1.5,
+                epss: 1.2,
+                production: 1.1,
+                old_build_days: 45,
+                old_build: 1.05,
+              },
+            },
+            {
+              identifier: "CVE-2025-0002",
+              packageName: "lodash",
+              description:
+                "Prototype pollution vulnerability allowing arbitrary property injection",
+              vulnerabilityDetailsLink:
+                "https://nvd.nist.gov/vuln/detail/CVE-2025-0002",
+              riskScore: 45,
+              riskScoreMultipliers: {
+                base_high: 50,
+                exposure: 1,
+                kev: 1,
+                epss: 1.1,
+                production: 1.1,
+                old_build_days: 20,
+                old_build: 1.02,
+              },
+            },
+          ],
+        },
+        {
+          id: "workload-002",
           name: "API Gateway",
           environment: "dev-gcp",
           repository: "navikt/api-gateway",


### PR DESCRIPTION
tried to follow patterns already present, but idk the ins and outs of this app :pray: 

my motivation for this patch is basically

- prior to this patch, applications are duplicated if they exist in multiple namespaces, so i made a set out of them
- environment should be filterable (e.g. i care the most about what's in production, so let me have a look!!)