### PR TITLE
base64 encoding is not compression

### DIFF
--- a/src/app/modules/vulnerabilities/utils/queryParamHelpers.test.ts
+++ b/src/app/modules/vulnerabilities/utils/queryParamHelpers.test.ts
@@ -93,23 +93,25 @@ describe("queryParamHelpers", () => {
       expect(params.get(QUERY_PARAM_KEYS.team)).toBe("team with spaces");
     });
 
-    it("should switch to compression for large filter lists", () => {
+    it("should use readable format for large filter lists", () => {
       // Create a filter list that will exceed 200 chars
+      const packageNames = Object.fromEntries(
+        Array.from({ length: 50 }, (_, i) => [`package-name-${i}`, true])
+      );
+
       const largeFilters = {
         teamFilters: {},
         applicationFilters: {},
         environmentFilters: {},
         cveFilters: {},
-        packageNameFilters: Object.fromEntries(
-          Array.from({ length: 50 }, (_, i) => [`package-name-${i}`, true])
-        ),
+        packageNameFilters: packageNames
       };
 
       const params = filtersToSearchParams(largeFilters);
       
       // Should use compressed format
-      expect(params.get(QUERY_PARAM_KEYS.compressed)).not.toBeNull();
-      expect(params.get(QUERY_PARAM_KEYS.pkg)).toBeNull();
+      expect(params.get(QUERY_PARAM_KEYS.compressed)).toBeNull();
+      expect(params.get(QUERY_PARAM_KEYS.pkg)).toBe(Object.keys(packageNames).join(","));
     });
 
     it("should use readable format for small filter lists", () => {

--- a/src/app/modules/vulnerabilities/utils/queryParamHelpers.ts
+++ b/src/app/modules/vulnerabilities/utils/queryParamHelpers.ts
@@ -23,17 +23,6 @@ export const QUERY_PARAM_KEYS = {
   compressed: "f", // Single compressed filter param
 } as const;
 
-// Threshold for switching to compression (characters)
-const COMPRESSION_THRESHOLD = 200;
-
-/**
- * Compress filters to base64 string
- */
-function compressFilters(filters: VulnerabilityFilters): string {
-  const json = JSON.stringify(filters);
-  return btoa(encodeURIComponent(json));
-}
-
 /**
  * Decompress base64 string to filters
  */
@@ -85,14 +74,6 @@ export function filtersToSearchParams(filters: VulnerabilityFilters): URLSearchP
 
   const pkgParam = serializeFilters(filters.packageNameFilters);
   if (pkgParam) params.set(QUERY_PARAM_KEYS.pkg, pkgParam);
-
-  // Check if URL is too long, switch to compression if needed
-  const readableUrl = params.toString();
-  if (readableUrl.length > COMPRESSION_THRESHOLD) {
-    const compressedParams = new URLSearchParams();
-    compressedParams.set(QUERY_PARAM_KEYS.compressed, compressFilters(filters));
-    return compressedParams;
-  }
 
   return params;
 }


### PR DESCRIPTION
the motivation for this pr is that i want to see the state of my filters at a glance (especially if it's a bookmarked url).  base64 encoding makes this impossible for a mere human such as myself.

additionally, the comments of the removed code imply that base64 _encoding_ has been used as a _compression_ scheme, which is not the case. the functions removed actually increase the url length by a _significant_ amount. the entire filter state has been used, serialized to json, _gets url-encoded first_ (ask your copilot "why?" please), before it is base64-encoded.
with my own simple tests in production, i can see that adding _one_ application to my filters (triggering the threshold), the url length balloons from 234 to 783. that's a _3.3x_ increase.

with all that said, i've kept the decoding functions as people may already have bookmarked the unwieldy base64 variants.